### PR TITLE
Fix output text for P06

### DIFF
--- a/categories/99-problems/P06-ajs.pl
+++ b/categories/99-problems/P06-ajs.pl
@@ -29,11 +29,12 @@ my @examples = [
     [[< E a >], False] ];
 
 for @examples -> ($list, $result) {
+    my $is-result = $result ?? "" !! "not ";
     if palindromic($list) != $result {
-        die "{$list.perl} was expected to be a palindrome, but isn't";
+        die "{$list.perl} was expected {$is-result}to be a palindrome, but isn't";
     }
     else {
-        say $list ~ " is a palindrome";
+        say $list ~ " is {$is-result}a palindrome";
     }
 }
 


### PR DESCRIPTION
Currently, the output text for `categories/99-problems/P06-ajs.pl` is:

```
a b c d E is a palindrome
a b c b a is a palindrome
a b b E is a palindrome
E b b a is a palindrome
a b b a is a palindrome
a is a palindrome
a a is a palindrome
E a is a palindrome
```

which is not correct. I changed the program a bit so it outputs:

```
a b c d E is not a palindrome
a b c b a is a palindrome
a b b E is not a palindrome
E b b a is not a palindrome
a b b a is a palindrome
a is a palindrome
a a is a palindrome
E a is not a palindrome
```